### PR TITLE
fix: :zap: Adds minify-syntax and minify-whitespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "module": "src/index.ts",
   "type": "module",
   "scripts": {
-    "build": "rimraf dist && bun build src/index.ts --outdir dist --target bun --minify -e elysia && tsc",
+    "build": "rimraf dist && bun build src/index.ts --outdir dist --target bun --minify-syntax --minify-whitespace -e elysia && tsc",
     "test": "bun test",
     "prepublishOnly": "bun run build"
   },


### PR DESCRIPTION
Bun build's `--minify` breaks Logestic's build, further identified it's specifically `--minify-identifiers` that is causing the issue https://github.com/cybercoder-naj/logestic/issues/33