### PR TITLE
fix: prevent logging for empty messages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -167,6 +167,9 @@ export class Logestic<K extends keyof Attribute = keyof Attribute> {
   }
 
   private async log(msg: string): Promise<void> {
+    // ignore empty logs
+    if (!msg || msg === "") return
+
     const msgNewLine = `${msg}\n`;
     if (!this.dest.name || !this.dest.name.length) {
       // This is either stdout or stderr


### PR DESCRIPTION
Added support for ignoring empty log messages.

This way logestic can be configured to ignore, for example, some status codes and don't generate log at all